### PR TITLE
README: cross off bash removal

### DIFF
--- a/README
+++ b/README
@@ -39,7 +39,6 @@ ls tmp-glibc/deploy/images/xen-stubdom/
 
 TODO
 Switch to MUSL?
-Remove bash
 Trim down busybox
 QEMU shrink?
 Remove QEMU keymaps?


### PR DESCRIPTION
Bash is now removed.

Signed-off-by: Jason Andryuk <jandryuk@gmail.com>